### PR TITLE
Documentation updates and SystemD fixes

### DIFF
--- a/ansible/roles/nginx/templates/librariesio
+++ b/ansible/roles/nginx/templates/librariesio
@@ -7,7 +7,6 @@ server {
   if ($http_x_forwarded_proto = "http") {
       return 301 https://$host$request_uri;
   }
-
   # ssl        on;
   # ssl_certificate         /root/certs/librariesio_cert.pem;
   # ssl_certificate_key     /root/certs/librariesio_key.pem;

--- a/ansible/roles/rails/files/librariesio.service
+++ b/ansible/roles/rails/files/librariesio.service
@@ -7,14 +7,14 @@ After=network.target
 
 [Service]
 # Foreground process (do not use --daemon in ExecStart or config.rb)
-Type=simple
+Type=forking
 
 # Preferably configure a non-privileged user
-# User=
+User=deploy
 
 # The path to the puma application root
 # Also replace the "<WD>" place holders below with this path.
-WorkingDirectory=/var/www/libraries/current/
+WorkingDirectory=/var/www/librariesio/current
 
 # Helpful for debugging socket activation, etc.
 # Environment=PUMA_DEBUG=1
@@ -22,13 +22,16 @@ WorkingDirectory=/var/www/libraries/current/
 # The command to start Puma. This variant uses a binstub generated via
 # `bundle binstubs puma --path ./sbin` in the WorkingDirectory
 # (replace "<WD>" below)
-ExecStart=/usr/local/bin/bundle exec puma -C config/puma.rb
+ExecStart=/usr/local/bin/bundle exec puma -C /var/www/librariesio/shared/puma.rb --daemon
 
 # Variant: Use config file with `bind` directives instead:
 # ExecStart=<WD>/sbin/puma -C config.rb
 # Variant: Use `bundle exec --keep-file-descriptors puma` instead of binstub
+ExecStop=/usr/local/bin/bundle exec pumactl -S /var/www/librariesio/shared/tmp/pids/puma.state stop
 
-Restart=always
+Restart=no
+
+PIDFile=/var/www/librariesio/shared/tmp/pids/puma.pid
 
 Environment=RAILS_ENV=production
 

--- a/ansible/roles/rails/tasks/main.yml
+++ b/ansible/roles/rails/tasks/main.yml
@@ -31,5 +31,13 @@
     dest: "/etc/systemd/system/librariesio.service"
     src: "librariesio.service"
 
+- name: Enable librariesio service
+  become: yes
+  systemd:
+    name: librariesio
+    enabled: yes
+    state: started
+    daemon_reload: yes
+
 - name: Hourly restart cron job
   cron: name="restart libraries" minute="{{ 59 | random(seed=inventory_hostname) }}" job="/sbin/restart librariesio > /dev/null 2>&1"

--- a/libraries_app.gcp.yml
+++ b/libraries_app.gcp.yml
@@ -13,5 +13,3 @@ auth_kind: serviceaccount
 filters:
   - labels.project = libraries
   - labels.type = app
-
-  


### PR DESCRIPTION
- Updated docs to specify appropriate ansible commands
- Updated SystemD unit to daemonize Puma so it can start on reboot and be restarted via Capistrano